### PR TITLE
Fixed some linter warnings

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,4 +3,8 @@ FROM postgres:${POSTGRESQL_VERSION}
 
 COPY Makefile *.control *.sql /src/
 
-RUN apt-get update && apt-get -y -qq install make && make -C /src install && apt-get clean
+RUN apt-get update \
+    && apt-get -y -qq install --no-install-recommends make \
+    && make -C /src install \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
DL3009 info: Delete the apt-get lists after installing something
DL3015 info: Avoid additional packages by specifying `--no-install-recommends`